### PR TITLE
FAK 订单回报处理

### DIFF
--- a/src/gateway/ctp/ctp_trade_api.cpp
+++ b/src/gateway/ctp/ctp_trade_api.cpp
@@ -327,7 +327,8 @@ void CtpTradeApi::OnRtnOrder(CThostFtdcOrderField *order) {
     OrderCancelRejection rsp = {order_id, gb2312_to_utf8(order->StatusMsg)};
     oms_->OnOrderCancelRejected(&rsp);
     return;
-  } else if (order->OrderSubmitStatus == THOST_FTDC_OSS_InsertSubmitted ||
+  } else if ((order->OrderSubmitStatus == THOST_FTDC_OSS_InsertSubmitted && 
+             order->OrderStatus == THOST_FTDC_OST_Canceled) ||
              order->OrderSubmitStatus == THOST_FTDC_OSS_CancelSubmitted) {
     return;
   }


### PR DESCRIPTION
若 FAK 订单提交成功后未成交被立即撤单，CTP 返回订单信息为
```c++
order->OrderSubmitStatus = THOST_FTDC_OSS_InsertSubmitted
order->OrderStatus = THOST_FTDC_OST_Canceled
```
在原判断条件下，该撤单信息会被直接过滤 return