### PR TITLE
FAK 撤单回报需要不被过滤

### DIFF
--- a/src/gateway/ctp/ctp_trade_api.cpp
+++ b/src/gateway/ctp/ctp_trade_api.cpp
@@ -328,7 +328,7 @@ void CtpTradeApi::OnRtnOrder(CThostFtdcOrderField *order) {
     oms_->OnOrderCancelRejected(&rsp);
     return;
   } else if ((order->OrderSubmitStatus == THOST_FTDC_OSS_InsertSubmitted && 
-             order->OrderStatus == THOST_FTDC_OST_Canceled) ||
+             order->OrderStatus != THOST_FTDC_OST_Canceled) ||
              order->OrderSubmitStatus == THOST_FTDC_OSS_CancelSubmitted) {
     return;
   }


### PR DESCRIPTION
sorry，之前手残提交快了，应该是两者同时满足条件不 return，所以判断 OrderStatus 应该是不等于

若 FAK 订单提交成功后未成交被立即撤单，CTP 返回订单信息为
```
order->OrderSubmitStatus = THOST_FTDC_OSS_InsertSubmitted
order->OrderStatus = THOST_FTDC_OST_Canceled
```
在原判断条件下，该撤单信息会被直接过滤 return