### PR TITLE
fix bugs in Strategy.run

### DIFF
--- a/src/strategy/strategy.cpp
+++ b/src/strategy/strategy.cpp
@@ -56,7 +56,7 @@ void Strategy::Run() {
         abort();
       }
       TickData* tick = reinterpret_cast<TickData*>(frame->getData());
-      OnTick(*tick);
+      OnTickMsg(*tick);
     }
   }
 }
@@ -83,7 +83,7 @@ void Strategy::RunBacktest() {
         abort();
       }
       TickData* tick = reinterpret_cast<TickData*>(frame->getData());
-      OnTick(*tick);
+      OnTickMsg(*tick);
       SendNotification(0);
     }
   }


### PR DESCRIPTION
把strategy.run中的OnTick替换为OnTickMsg，原来的OnTick导致TargetPosEngine无法起作用